### PR TITLE
Fixed positioning error when draggable matching quiz has multiple pages.

### DIFF
--- a/app/scripts/component/npDragAndDropMatch/npDragAndDropMatch.js
+++ b/app/scripts/component/npDragAndDropMatch/npDragAndDropMatch.js
@@ -189,8 +189,6 @@
                             Draggable.create(element, {
                                 type: "x,y",
                                 edgeResistance: 0.65,
-//                                autoScroll: 1,
-                                bounds: "#draggableContainer",
                                 throwProps: true,
                                 overlapThreshold: '50%',
                                 onDrag: function (e) {


### PR DESCRIPTION
This will requires a rebuild, which we have not been able to do ourselves.